### PR TITLE
Pv 935 text ep split

### DIFF
--- a/src/es_data_load/pv/mappings/PVMappingsManager.py
+++ b/src/es_data_load/pv/mappings/PVMappingsManager.py
@@ -30,7 +30,11 @@ AVAILABLE_MAPPING_FILES = {
     ],
     "pregrant": [
         "publications.json",
-        "rel_app_text_publications.json"
+        "rel_app_text_publications.json",
+        "claim.json",
+        "brf_sum_text.json",
+        "detail_desc_text.json",
+        "draw_desc_text.json",
     ],
 }
 

--- a/src/es_data_load/pv/mappings/production/granted/brf_sum_text.json
+++ b/src/es_data_load/pv/mappings/production/granted/brf_sum_text.json
@@ -1,18 +1,19 @@
 {
   "source_setting": {
-    "source": "select c.uuid, patent_id, summary_text, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix, from (select uuid from {elastic_production_source}.g_brf_sum_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.g_brf_sum_text c on c.uuid=inner_q.uuid",
+    "source": "select c.uuid, patent_id, summary_text, document_date, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix, from {elastic_production_source}.g_brf_sum_text_delta where uuid > '{{offset}}' order by uuid limit {{limit}}",
     "field_mapping": {
       "uuid": 0,
       "patent_id": 1,
       "summary_text": 2,
-      "patent_zero_prefix": 3
+      "document_date": 3,
+      "patent_zero_prefix": 4
     },
-    "count_source": "select count(1) from {elastic_production_source}.g_brf_sum_text",
+    "count_source": "select count(1) from {elastic_production_source}.g_brf_sum_text_delta",
     "key_field": "uuid",
     "chunksize": 100000
   },
   "target_setting": {
-    "index": "g_brf_sum_text",
+    "index": "g_brf_sum_texts",
     "indexing_batch_size": 5000,
     "id_field": "uuid"
   }

--- a/src/es_data_load/pv/mappings/production/granted/brf_sum_text.json
+++ b/src/es_data_load/pv/mappings/production/granted/brf_sum_text.json
@@ -1,19 +1,18 @@
 {
   "source_setting": {
-    "source": "select     c.uuid, patent_id, summary_text, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix, document_number from (select uuid from {elastic_production_source}.brf_sum_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.brf_sum_text c on c.uuid=inner_q.uuid",
+    "source": "select c.uuid, patent_id, summary_text, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix, from (select uuid from {elastic_production_source}.g_brf_sum_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.g_brf_sum_text c on c.uuid=inner_q.uuid",
     "field_mapping": {
       "uuid": 0,
       "patent_id": 1,
       "summary_text": 2,
-      "patent_zero_prefix": 3,
-      "document_number": 4
+      "patent_zero_prefix": 3
     },
-    "count_source": "select count(1) from {elastic_production_source}.brf_sum_text",
+    "count_source": "select count(1) from {elastic_production_source}.g_brf_sum_text",
     "key_field": "uuid",
     "chunksize": 100000
   },
   "target_setting": {
-    "index": "brf_sum_text",
+    "index": "g_brf_sum_text",
     "indexing_batch_size": 5000,
     "id_field": "uuid"
   }

--- a/src/es_data_load/pv/mappings/production/granted/claim.json
+++ b/src/es_data_load/pv/mappings/production/granted/claim.json
@@ -1,6 +1,6 @@
 {
   "source_setting": {
-    "source": "select c.uuid, patent_id, claim_number, claim_text, exemplary, claim_sequence, dependent, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix from (select uuid from {elastic_production_source}.g_claims where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.g_claims c on c.uuid=inner_q.uuid",
+    "source": "select c.uuid, patent_id, claim_number, claim_text, exemplary, claim_sequence, dependent, document_date, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix from {elastic_production_source}.g_claim_delta where uuid > '{{offset}}' order by uuid limit {{limit}}",
     "field_mapping": {
       "uuid": 0,
       "patent_id": 1,
@@ -9,14 +9,15 @@
       "exemplary": 4,
       "claim_sequence": 5,
       "claim_dependent": 6,
-      "patent_zero_prefix": 7
+      "document_date": 7,
+      "patent_zero_prefix": 8
     },
     "key_field": "uuid",
-    "count_source": "select count(1) from {elastic_production_source}.g_claims",
+    "count_source": "select count(1) from {elastic_production_source}.g_claim_delta",
     "chunksize": 1000000
   },
   "target_setting": {
-    "index": "g_claim",
+    "index": "g_claims",
     "indexing_batch_size": 100000,
     "id_field": "uuid"
   }

--- a/src/es_data_load/pv/mappings/production/granted/claim.json
+++ b/src/es_data_load/pv/mappings/production/granted/claim.json
@@ -1,6 +1,6 @@
 {
   "source_setting": {
-    "source": "select c.uuid, patent_id, claim_number, claim_text, exemplary, claim_sequence, dependent, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix, document_number from (select uuid from {elastic_production_source}.claims where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.claims c on c.uuid=inner_q.uuid",
+    "source": "select c.uuid, patent_id, claim_number, claim_text, exemplary, claim_sequence, dependent, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix from (select uuid from {elastic_production_source}.g_claims where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.g_claims c on c.uuid=inner_q.uuid",
     "field_mapping": {
       "uuid": 0,
       "patent_id": 1,
@@ -9,15 +9,14 @@
       "exemplary": 4,
       "claim_sequence": 5,
       "claim_dependent": 6,
-      "patent_zero_prefix": 7,
-      "document_number": 8
+      "patent_zero_prefix": 7
     },
     "key_field": "uuid",
-    "count_source": "select count(1) from {elastic_production_source}.claims",
+    "count_source": "select count(1) from {elastic_production_source}.g_claims",
     "chunksize": 1000000
   },
   "target_setting": {
-    "index": "claim",
+    "index": "g_claim",
     "indexing_batch_size": 100000,
     "id_field": "uuid"
   }

--- a/src/es_data_load/pv/mappings/production/granted/cpc_class.json
+++ b/src/es_data_load/pv/mappings/production/granted/cpc_class.json
@@ -14,7 +14,7 @@
       "cpc_class_years_active": 8
     },
     "key_field": "uuid",
-    "count_source": "SELECT count(1) from  {elastic_production_source}.cpc_class",
+    "count_source": "SELECT count(1) from {elastic_production_source}.cpc_class",
     "chunksize": 1000000
   },
   "target_setting": {

--- a/src/es_data_load/pv/mappings/production/granted/cpc_class.json
+++ b/src/es_data_load/pv/mappings/production/granted/cpc_class.json
@@ -2,7 +2,6 @@
   "source_setting": {
     "source": "select id, id, title, num_assignees, num_inventors, num_patents, first_seen_date, last_seen_date, years_active from {elastic_production_source}.cpc_class where id > '{{offset}}' order by id limit {{limit}};",
     "field_mapping": {
-      "uuid": 0,
       "cpc_class_id": 1,
       "cpc_class_title": 2,
       "cpc_class": 1,

--- a/src/es_data_load/pv/mappings/production/granted/cpc_group.json
+++ b/src/es_data_load/pv/mappings/production/granted/cpc_group.json
@@ -2,7 +2,6 @@
   "source_setting": {
     "source": "select id, id, SUBSTR(id, 1, 3) class, SUBSTR(id, 1, 4) subclass, title from {elastic_production_source}.cpc_group where id > '{{offset}}' order by id limit {{limit}};",
     "field_mapping": {
-      "uuid": 0,
       "cpc_class": 2,
       "cpc_class_id": 2,
       "cpc_subclass_id": 3,

--- a/src/es_data_load/pv/mappings/production/granted/cpc_group.json
+++ b/src/es_data_load/pv/mappings/production/granted/cpc_group.json
@@ -1,6 +1,6 @@
 {
   "source_setting": {
-    "source": "select id, id, SUBSTR(id,1,3) class, SUBSTR(id,1,4) subclass, title from {elastic_production_source}.cpc_group where id > '{{offset}}' order by id limit {{limit}};",
+    "source": "select id, id, SUBSTR(id, 1, 3) class, SUBSTR(id, 1, 4) subclass, title from {elastic_production_source}.cpc_group where id > '{{offset}}' order by id limit {{limit}};",
     "field_mapping": {
       "uuid": 0,
       "cpc_class": 2,
@@ -10,7 +10,7 @@
       "cpc_group_id":1,
       "cpc_group_title": 4
     },
-    "count_source": "SELECT count(1) from  {elastic_production_source}.cpc_group",
+    "count_source": "SELECT count(1) from {elastic_production_source}.cpc_group",
     "chunksize": 1000000,
         "key_field": "uuid"
   },

--- a/src/es_data_load/pv/mappings/production/granted/cpc_subclass.json
+++ b/src/es_data_load/pv/mappings/production/granted/cpc_subclass.json
@@ -1,6 +1,6 @@
 {
   "source_setting": {
-    "source": "select id, SUBSTR(id,1,3 ) class_id,id , title, num_assignees, num_inventors, num_patents, first_seen_date, last_seen_date, years_active from {elastic_production_source}.cpc_subclass where id > '{{offset}}' order by id limit {{limit}};",
+    "source": "select id, SUBSTR(id, 1, 3 ) class_id, id , title, num_assignees, num_inventors, num_patents, first_seen_date, last_seen_date, years_active from {elastic_production_source}.cpc_subclass where id > '{{offset}}' order by id limit {{limit}};",
     "field_mapping": {
       "uuid": 0,
       "cpc_class": 1,
@@ -15,7 +15,7 @@
       "cpc_subclass_last_seen_date": 8,
       "cpc_subclass_years_active": 9
     },
-    "count_source": "SELECT count(1) from  {elastic_production_source}.cpc_subclass",
+    "count_source": "SELECT count(1) from {elastic_production_source}.cpc_subclass",
     "chunksize": 1000000,
         "key_field": "uuid"
   },

--- a/src/es_data_load/pv/mappings/production/granted/detail_desc_text.json
+++ b/src/es_data_load/pv/mappings/production/granted/detail_desc_text.json
@@ -1,15 +1,14 @@
 {
   "source_setting": {
-    "source": "select     c.uuid, patent_id, description_text, description_length,  CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix, document_number from (select uuid from {elastic_production_source}.detail_desc_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.detail_desc_text c on c.uuid=inner_q.uuid",
+    "source": "select     c.uuid, patent_id, description_text, description_length,  CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix from (select uuid from {elastic_production_source}.g_detail_desc_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.g_detail_desc_text c on c.uuid=inner_q.uuid",
     "field_mapping": {
       "uuid": 0,
       "patent_id": 1,
       "description_text": 2,
       "description_length": 3,
-      "patent_zero_prefix": 4,
-      "document_number": 5
+      "patent_zero_prefix": 4
     },
-    "count_source": "select count(1) from {elastic_production_source}.detail_desc_text",
+    "count_source": "select count(1) from {elastic_production_source}.g_detail_desc_text",
     "key_field": "uuid",
     "chunksize": 100000
   },

--- a/src/es_data_load/pv/mappings/production/granted/detail_desc_text.json
+++ b/src/es_data_load/pv/mappings/production/granted/detail_desc_text.json
@@ -1,6 +1,6 @@
 {
   "source_setting": {
-    "source": "select     c.uuid, patent_id, description_text, description_length,  CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix from (select uuid from {elastic_production_source}.g_detail_desc_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.g_detail_desc_text c on c.uuid=inner_q.uuid",
+    "source": "select c.uuid, patent_id, description_text, description_length, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix from (select uuid from {elastic_production_source}.g_detail_desc_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.g_detail_desc_text c on c.uuid=inner_q.uuid",
     "field_mapping": {
       "uuid": 0,
       "patent_id": 1,

--- a/src/es_data_load/pv/mappings/production/granted/detail_desc_text.json
+++ b/src/es_data_load/pv/mappings/production/granted/detail_desc_text.json
@@ -1,19 +1,20 @@
 {
   "source_setting": {
-    "source": "select c.uuid, patent_id, description_text, description_length, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix from (select uuid from {elastic_production_source}.g_detail_desc_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.g_detail_desc_text c on c.uuid=inner_q.uuid",
+    "source": "select c.uuid, patent_id, description_text, description_length, document_date, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix from {elastic_production_source}.g_detail_desc_text_delta where uuid > '{{offset}}' order by uuid limit {{limit}}",
     "field_mapping": {
       "uuid": 0,
       "patent_id": 1,
       "description_text": 2,
       "description_length": 3,
-      "patent_zero_prefix": 4
+      "document_date": 4,
+      "patent_zero_prefix": 5
     },
-    "count_source": "select count(1) from {elastic_production_source}.g_detail_desc_text",
+    "count_source": "select count(1) from {elastic_production_source}.g_detail_desc_text_delta",
     "key_field": "uuid",
     "chunksize": 100000
   },
   "target_setting": {
-    "index": "detail_desc_text",
+    "index": "detail_desc_texts",
     "indexing_batch_size": 1000,
     "id_field": "uuid"
   }

--- a/src/es_data_load/pv/mappings/production/granted/draw_desc_text.json
+++ b/src/es_data_load/pv/mappings/production/granted/draw_desc_text.json
@@ -1,19 +1,20 @@
 {
   "source_setting": {
-    "source": "select c.uuid, patent_id, draw_desc_text, draw_desc_sequence, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix from (select uuid from {elastic_production_source}.g_draw_desc_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.g_draw_desc_text c on c.uuid=inner_q.uuid",
+    "source": "select c.uuid, patent_id, draw_desc_text, draw_desc_sequence, document_number, document_date, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix from {elastic_production_source}.g_draw_desc_text_delta where uuid > '{{offset}}' order by uuid limit {{limit}}",
     "field_mapping": {
       "uuid": 0,
       "patent_id": 1,
       "description_text": 2,
       "description_sequence": 3,
-      "patent_zero_prefix": 4
+      "document_date": 4,
+      "patent_zero_prefix": 5
     },
-    "count_source": "select count(1) from {elastic_production_source}.g_draw_desc_text",
+    "count_source": "select count(1) from {elastic_production_source}.g_draw_desc_text_delta",
     "key_field": "uuid",
     "chunksize": 100000
   },
   "target_setting": {
-    "index": "draw_desc_text",
+    "index": "draw_desc_texts",
     "indexing_batch_size": 15000,
     "id_field": "uuid"
   }

--- a/src/es_data_load/pv/mappings/production/granted/draw_desc_text.json
+++ b/src/es_data_load/pv/mappings/production/granted/draw_desc_text.json
@@ -1,15 +1,14 @@
 {
   "source_setting": {
-    "source": "select c.uuid, patent_id, draw_desc_text, draw_desc_sequence, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix, document_number from (select uuid from {elastic_production_source}.draw_desc_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.draw_desc_text c on c.uuid=inner_q.uuid",
+    "source": "select c.uuid, patent_id, draw_desc_text, draw_desc_sequence, CONCAT(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+'), LPAD(REGEXP_SUBSTR(patent_id, '[0-9]+$'), 8-LENGTH(REGEXP_SUBSTR(patent_id, '^[a-zA-Z]+')), '0')) as patent_zero_prefix from (select uuid from {elastic_production_source}.g_draw_desc_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.g_draw_desc_text c on c.uuid=inner_q.uuid",
     "field_mapping": {
       "uuid": 0,
       "patent_id": 1,
       "description_text": 2,
       "description_sequence": 3,
-      "patent_zero_prefix": 4,
-      "document_number": 5
+      "patent_zero_prefix": 4
     },
-    "count_source": "select count(1) from {elastic_production_source}.draw_desc_text",
+    "count_source": "select count(1) from {elastic_production_source}.g_draw_desc_text",
     "key_field": "uuid",
     "chunksize": 100000
   },

--- a/src/es_data_load/pv/mappings/production/granted/ipcr.json
+++ b/src/es_data_load/pv/mappings/production/granted/ipcr.json
@@ -8,7 +8,7 @@
       "ipc_class": 2 ,
       "ipc_subclass": 3
     },
-    "count_source": "SELECT count(1) from  {elastic_production_source}.ipcr",
+    "count_source": "SELECT count(1) from {elastic_production_source}.ipcr",
     "chunksize": 1000000,
         "key_field": "uuid"
   },

--- a/src/es_data_load/pv/mappings/production/granted/patents.json
+++ b/src/es_data_load/pv/mappings/production/granted/patents.json
@@ -1,6 +1,6 @@
 {
   "source_setting": {
-    "source": "SELECT p.patent_id, type  , date  , year  , title  , abstract  , kind  , detail_desc_length  , num_foreign_documents_cited  , num_us_patents_cited  , num_us_applications_cited  , num_total_documents_cited  , num_times_cited_by_us_patents  , cpc_current_group_average_patent_processing_days  , uspc_current_mainclass_average_patent_processing_days  , patent_processing_days  , earliest_application_date  , term_extension, gi_statement, patent_zero_prefix from {elastic_production_source}.patents p join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p2 on p2.patent_id=p.patent_id;",
+    "source": "SELECT p.patent_id, type , date , year , title , abstract , kind , detail_desc_length , num_foreign_documents_cited , num_us_patents_cited , num_us_applications_cited , num_total_documents_cited , num_times_cited_by_us_patents , cpc_current_group_average_patent_processing_days , uspc_current_mainclass_average_patent_processing_days , patent_processing_days , earliest_application_date , term_extension, gi_statement, patent_zero_prefix from {elastic_production_source}.patents p join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p2 on p2.patent_id=p.patent_id;",
     "field_mapping": {
       "patent_id": 0,
       "patent_title": 4,
@@ -26,7 +26,7 @@
     "key_field": "patent_id",
     "nested_fields": {
       "application": {
-        "source": "select a.application_id, a.type, a.date,a.series_code,case when a.rule_47_flag=0 then 'false' else 'true' end,a.type, a.patent_id from {elastic_production_source}.patent_application a join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=a.patent_id",
+        "source": "select a.application_id, a.type, a.date, a.series_code, case when a.rule_47_flag=0 then 'false' else 'true' end, a.type, a.patent_id from {elastic_production_source}.patent_application a join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=a.patent_id",
         "field_mapping": {
           "application_id": 0,
           "application_type": 1,
@@ -38,7 +38,7 @@
         }
       },
       "attorneys": {
-        "source": "select a.persistent_lawyer_id, a.name_first, a.name_last,a.organization,a.sequence, a.patent_id from {elastic_production_source}.patent_attorneys a join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=a.patent_id",
+        "source": "select a.persistent_lawyer_id, a.name_first, a.name_last, a.organization, a.sequence, a.patent_id from {elastic_production_source}.patent_attorneys a join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=a.patent_id",
         "field_mapping": {
           "attorney_id": 0,
           "attorney_name_first": 1,
@@ -57,7 +57,7 @@
         }
       },
       "cpc_at_issue": {
-        "source": "select c.sequence, c.cpc_section, c.cpc_class,c.cpc_class,c.cpc_subclass,c.cpc_subclass, c.cpc_group,c.cpc_group,c.cpc_type, c.patent_id from {elastic_production_source}.patent_cpc_at_issue c join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=c.patent_id",
+        "source": "select c.sequence, c.cpc_section, c.cpc_class, c.cpc_class, c.cpc_subclass, c.cpc_subclass, c.cpc_group, c.cpc_group, c.cpc_type, c.patent_id from {elastic_production_source}.patent_cpc_at_issue c join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=c.patent_id",
         "field_mapping": {
           "cpc_sequence": 0,
           "cpc_section": 1,
@@ -72,7 +72,7 @@
         }
       },
       "examiners": {
-        "source": "select e.persistent_examiner_id,e.name_first,e.name_last,e.role,e.`group`,e.patent_id from {elastic_production_source}.patent_examiner e join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=e.patent_id",
+        "source": "select e.persistent_examiner_id, e.name_first, e.name_last, e.role, e.`group`,e.patent_id from {elastic_production_source}.patent_examiner e join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=e.patent_id",
         "field_mapping": {
           "examiner_id": 0,
           "examiner_first_name": 1,
@@ -83,7 +83,7 @@
         }
       },
       "granted_pregrant_crosswalk": {
-        "source": "select g.patent_id,g.document_number,g.document_number,g.application_number from {elastic_production_source}.granted_pregrant_crosswalk g join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=g.patent_id",
+        "source": "select g.patent_id, g.document_number, g.document_number, g.application_number from {elastic_production_source}.granted_pregrant_crosswalk g join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=g.patent_id",
         "field_mapping": {
           "patent_id": 0,
           "document_number": 1,
@@ -100,7 +100,7 @@
         }
       },
       "foreign_priority": {
-        "source": "select f.sequence,f.kind,f.foreign_doc_number,f.date,f.country,f.patent_id from {elastic_production_source}.patent_foreign_priority f join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=f.patent_id",
+        "source": "select f.sequence, f.kind, f.foreign_doc_number, f.date, f.country, f.patent_id from {elastic_production_source}.patent_foreign_priority f join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=f.patent_id",
         "field_mapping": {
           "priority_claim_sequence": 0,
           "priority_claim_kind": 1,
@@ -111,14 +111,14 @@
         }
       },
       "gov_interest_contract_award_numbers": {
-        "source": "select c.award_number,c.patent_id   from {elastic_production_source}.patent_gov_contract c join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on c.patent_id = p.patent_id;",
+        "source": "select c.award_number, c.patent_id from {elastic_production_source}.patent_gov_contract c join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on c.patent_id = p.patent_id;",
         "field_mapping": {
           "award_number": 0,
           "patent_id": 1
         }
       },
       "gov_interest_organizations": {
-        "source": "select c.name,c.level_one,c.level_two,c.level_three,c.patent_id  from {elastic_production_source}.patent_gov_interest_organizations c join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on c.patent_id = p.patent_id;",
+        "source": "select c.name, c.level_one, c.level_two, c.level_three, c.patent_id from {elastic_production_source}.patent_gov_interest_organizations c join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on c.patent_id = p.patent_id;",
         "field_mapping": {
           "fedagency_name": 0,
           "level_one": 1,
@@ -145,7 +145,7 @@
         }
       },
       "applicants": {
-        "source": "select a.fname,a.lname,a.organization,a.sequence,a.designation,a.applicant_type,a.persistent_location_id,a.patent_id from {elastic_production_source}.patent_applicant  a join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on p.patent_id = a.patent_id;",
+        "source": "select a.fname, a.lname, a.organization, a.sequence, a.designation, a.applicant_type, a.persistent_location_id, a.patent_id from {elastic_production_source}.patent_applicant a join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on p.patent_id = a.patent_id;",
         "field_mapping": {
           "applicant_name_first": 0,
           "applicant_name_last": 1,
@@ -158,7 +158,7 @@
         }
       },
       "pct_data": {
-        "source": "select p.date,p.`102_date`,p.`371_date`,p.kind,p.doc_number,p.doc_type, p.patent_id from {elastic_production_source}.patent_pct_data  p join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p2 on p.patent_id = p2.patent_id;",
+        "source": "select p.date, p.`102_date`,p.`371_date`,p.kind, p.doc_number, p.doc_type, p.patent_id from {elastic_production_source}.patent_pct_data p join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p2 on p.patent_id = p2.patent_id;",
         "field_mapping": {
           "published_filed_date": 0,
           "pct_102_date": 1,
@@ -170,7 +170,7 @@
         }
       },
       "us_related_documents": {
-        "source": "select u.doctype,u.kind,u.reldocno,u.country,u.date,u.status,u.sequence,u.kind,u.patent_id   from {elastic_production_source}.patent_us_related_documents u join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on u.patent_id = p.patent_id;",
+        "source": "select u.doctype, u.kind, u.reldocno, u.country, u.date, u.status, u.sequence, u.kind, u.patent_id from {elastic_production_source}.patent_us_related_documents u join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on u.patent_id = p.patent_id;",
         "field_mapping": {
           "related_doc_type": 0,
           "related_doc_kind": 1,
@@ -184,7 +184,7 @@
         }
       },
       "us_term_of_grant": {
-        "source": "select u.term_grant,u.term_extension,u.term_disclaimer,u.disclaimer_date,u.patent_id from {elastic_production_source}.patent_us_term_of_grant  u join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on u.patent_id = p.patent_id;",
+        "source": "select u.term_grant, u.term_extension, u.term_disclaimer, u.disclaimer_date, u.patent_id from {elastic_production_source}.patent_us_term_of_grant u join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on u.patent_id = p.patent_id;",
         "field_mapping": {
           "term_grant": 0,
           "term_extension": 1,
@@ -194,7 +194,7 @@
         }
       },
       "uspc_at_issue": {
-        "source": "select u.mainclass_id,u.mainclass_id,u.subclass_id,u.subclass_id,u.sequence,u.patent_id from {elastic_production_source}.patent_uspc_at_issue  u join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on u.patent_id = p.patent_id;",
+        "source": "select u.mainclass_id, u.mainclass_id, u.subclass_id, u.subclass_id, u.sequence, u.patent_id from {elastic_production_source}.patent_uspc_at_issue u join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on u.patent_id = p.patent_id;",
         "field_mapping": {
           "uspc_mainclass": 0,
           "uspc_mainclass_id": 1,
@@ -205,7 +205,7 @@
         }
       },
       "wipo": {
-        "source": "select w.field_id,w.field_id,w.sequence,w.patent_id from {elastic_production_source}.patent_wipo  w join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on w.patent_id = p.patent_id;",
+        "source": "select w.field_id, w.field_id, w.sequence, w.patent_id from {elastic_production_source}.patent_wipo w join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}}) p on w.patent_id = p.patent_id;",
         "field_mapping": {
           "wipo_field_id": 0,
           "wipo_field": 1,
@@ -214,7 +214,7 @@
         }
       },
       "assignees": {
-        "source": "SELECT  persistent_assignee_id  , name_first  , name_last  , organization  , sequence  , type  , city  , state  , country  , a.patent_id  , persistent_location_id from {elastic_production_source}.patent_assignee a join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=a.patent_id",
+        "source": "SELECT persistent_assignee_id , name_first , name_last , organization , sequence , type , city , state , country , a.patent_id , persistent_location_id from {elastic_production_source}.patent_assignee a join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=a.patent_id",
         "field_mapping": {
           "assignee_id": 0,
           "assignee_type": 5,
@@ -230,7 +230,7 @@
         }
       },
       "inventors": {
-        "source": "select persistent_inventor_id, name_first, name_last, sequence,city, state, country, i.patent_id, persistent_location_id from {elastic_production_source}.patent_inventor i join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=i.patent_id",
+        "source": "select persistent_inventor_id, name_first, name_last, sequence, city, state, country, i.patent_id, persistent_location_id from {elastic_production_source}.patent_inventor i join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=i.patent_id",
         "field_mapping": {
           "inventor_id": 0,
           "inventor_name_first": 1,
@@ -244,7 +244,7 @@
         }
       },
       "cpc_current": {
-        "source": "select c.sequence, c.cpc_section, c.cpc_class,c.cpc_class,c.cpc_subclass,c.cpc_subclass, c.cpc_group,c.cpc_group,c.cpc_type, c.patent_id from {elastic_production_source}.patent_cpc_current as c join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=c.patent_id",
+        "source": "select c.sequence, c.cpc_section, c.cpc_class, c.cpc_class, c.cpc_subclass, c.cpc_subclass, c.cpc_group, c.cpc_group, c.cpc_type, c.patent_id from {elastic_production_source}.patent_cpc_current as c join (select patent_id from {elastic_production_source}.patents where patent_id > '{{offset}}' order by patent_id limit {{limit}})p on p.patent_id=c.patent_id",
         "field_mapping": {
           "cpc_sequence": 0,
           "cpc_section": 1,

--- a/src/es_data_load/pv/mappings/production/granted/us_application_citations.json
+++ b/src/es_data_load/pv/mappings/production/granted/us_application_citations.json
@@ -15,7 +15,7 @@
     },
         "key_field": "uuid",
 
-    "count_source": "SELECT count(1) from  {elastic_production_source}.us_application_citations",
+    "count_source": "SELECT count(1) from {elastic_production_source}.us_application_citations",
     "chunksize": 10000
   },
   "target_setting": {

--- a/src/es_data_load/pv/mappings/production/granted/us_patent_citations.json
+++ b/src/es_data_load/pv/mappings/production/granted/us_patent_citations.json
@@ -16,7 +16,7 @@
     },
         "key_field": "uuid",
 
-    "count_source": "SELECT count(1) from  {elastic_production_source}.us_patent_citations",
+    "count_source": "SELECT count(1) from {elastic_production_source}.us_patent_citations",
     "chunksize": 10000
   },
   "target_setting": {

--- a/src/es_data_load/pv/mappings/production/granted/uspc_mainclass.json
+++ b/src/es_data_load/pv/mappings/production/granted/uspc_mainclass.json
@@ -2,7 +2,6 @@
   "source_setting": {
     "source": "select id, id, title, num_patents, num_inventors, num_assignees, first_seen_date, last_seen_date, years_active from {reporting_data_source}.uspc_mainclass where id > '{{offset}}' order by id limit {{limit}};",
     "field_mapping": {
-      "uuid": 0,
       "uspc_mainclass_id": 1,
       "uspc_mainclass_title": 2,
       "uspc_mainclass_num_assignees": 5,

--- a/src/es_data_load/pv/mappings/production/granted/uspc_mainclass.json
+++ b/src/es_data_load/pv/mappings/production/granted/uspc_mainclass.json
@@ -14,7 +14,7 @@
     },
         "key_field": "uuid",
 
-    "count_source": "SELECT count(1) from  {reporting_data_source}.uspc_mainclass",
+    "count_source": "SELECT count(1) from {reporting_data_source}.uspc_mainclass",
     "chunksize": 1000000
   },
   "target_setting": {

--- a/src/es_data_load/pv/mappings/production/granted/uspc_subclass.json
+++ b/src/es_data_load/pv/mappings/production/granted/uspc_subclass.json
@@ -10,7 +10,7 @@
     },
       "key_field": "uuid",
 
-    "count_source": "SELECT count(1) from  {reporting_data_source}.uspc_subclass",
+    "count_source": "SELECT count(1) from {reporting_data_source}.uspc_subclass",
     "chunksize": 1000000
   },
   "target_setting": {

--- a/src/es_data_load/pv/mappings/production/granted/wipo.json
+++ b/src/es_data_load/pv/mappings/production/granted/wipo.json
@@ -1,13 +1,13 @@
 {
   "source_setting": {
-    "source": "select id, sector_title,field_title from {elastic_production_source}.wipo_field where id > '{{offset}}' order by id limit {{limit}};",
+    "source": "select id, sector_title, field_title from {elastic_production_source}.wipo_field where id > '{{offset}}' order by id limit {{limit}};",
     "field_mapping": {
       "uuid": 0,
       "wipo_id": 0,
       "sector_title": 1,
       "field_title": 2
     },
-    "count_source": "SELECT count(1) from   {elastic_production_source}.wipo_field",
+    "count_source": "SELECT count(1) from {elastic_production_source}.wipo_field",
     "chunksize": 10000,
     "key_field": "uuid"
   },

--- a/src/es_data_load/pv/mappings/production/pregrant/brf_sum_text.json
+++ b/src/es_data_load/pv/mappings/production/pregrant/brf_sum_text.json
@@ -1,0 +1,19 @@
+{
+  "source_setting": {
+    "source": "select c.uuid, document_number, summary_text from (select uuid from {elastic_production_source}.pg_brf_sum_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.pg_brf_sum_text c on c.uuid=inner_q.uuid",
+    "field_mapping": {
+      "uuid": 0,
+      "document_number": 1,
+      "summary_text": 2
+    },
+    "count_source": "select count(1) from {elastic_production_source}.pg_brf_sum_text",
+    "key_field": "uuid",
+    "chunksize": 100000
+  },
+  "target_setting": {
+    "index": "pg_brf_sum_text",
+    "indexing_batch_size": 5000,
+    "id_field": "uuid"
+  }
+}
+

--- a/src/es_data_load/pv/mappings/production/pregrant/brf_sum_text.json
+++ b/src/es_data_load/pv/mappings/production/pregrant/brf_sum_text.json
@@ -1,17 +1,18 @@
 {
   "source_setting": {
-    "source": "select c.uuid, document_number, summary_text from (select uuid from {elastic_production_source}.pg_brf_sum_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}.pg_brf_sum_text c on c.uuid=inner_q.uuid",
+    "source": "select c.uuid, document_number, summary_text, document_date from {elastic_production_source}.pg_brf_sum_text_delta where uuid > '{{offset}}' order by uuid limit {{limit}}",
     "field_mapping": {
       "uuid": 0,
       "document_number": 1,
-      "summary_text": 2
+      "summary_text": 2,
+      "document_date": 3
     },
-    "count_source": "select count(1) from {elastic_production_source}.pg_brf_sum_text",
+    "count_source": "select count(1) from {elastic_production_source}.pg_brf_sum_text_delta",
     "key_field": "uuid",
     "chunksize": 100000
   },
   "target_setting": {
-    "index": "pg_brf_sum_text",
+    "index": "pg_brf_sum_texts",
     "indexing_batch_size": 5000,
     "id_field": "uuid"
   }

--- a/src/es_data_load/pv/mappings/production/pregrant/claim.json
+++ b/src/es_data_load/pv/mappings/production/pregrant/claim.json
@@ -1,20 +1,21 @@
 {
   "source_setting": {
-    "source": "select c.uuid, document_number, claim_number, claim_text, claim_sequence, dependent from (select uuid from {elastic_production_source}pg_claims where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}pg_claims c on c.uuid=inner_q.uuid",
+    "source": "select c.uuid, document_number, claim_number, claim_text, claim_sequence, dependent, document_date from {elastic_production_source}.pg_claim_delta where uuid > '{{offset}}' order by uuid limit {{limit}}",
     "field_mapping": {
       "uuid": 0,
       "document_number": 1,
       "claim_number": 2,
       "claim_text": 3,
       "claim_sequence": 4,
-      "claim_dependent": 5
+      "claim_dependent": 5,
+      "document_date": 6
     },
     "key_field": "uuid",
-    "count_source": "select count(1) from {elastic_production_source}pg_claims",
+    "count_source": "select count(1) from {elastic_production_source}.pg_claim_delta",
     "chunksize": 1000000
   },
   "target_setting": {
-    "index": "pg_claim",
+    "index": "pg_claims",
     "indexing_batch_size": 100000,
     "id_field": "uuid"
   }

--- a/src/es_data_load/pv/mappings/production/pregrant/claim.json
+++ b/src/es_data_load/pv/mappings/production/pregrant/claim.json
@@ -1,0 +1,21 @@
+{
+  "source_setting": {
+    "source": "select c.uuid, document_number, claim_number, claim_text, claim_sequence, dependent from (select uuid from {elastic_production_source}pg_claims where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}pg_claims c on c.uuid=inner_q.uuid",
+    "field_mapping": {
+      "uuid": 0,
+      "document_number": 1,
+      "claim_number": 2,
+      "claim_text": 3,
+      "claim_sequence": 4,
+      "claim_dependent": 5
+    },
+    "key_field": "uuid",
+    "count_source": "select count(1) from {elastic_production_source}pg_claims",
+    "chunksize": 1000000
+  },
+  "target_setting": {
+    "index": "pg_claim",
+    "indexing_batch_size": 100000,
+    "id_field": "uuid"
+  }
+}

--- a/src/es_data_load/pv/mappings/production/pregrant/detail_desc_text.json
+++ b/src/es_data_load/pv/mappings/production/pregrant/detail_desc_text.json
@@ -1,18 +1,19 @@
 {
   "source_setting": {
-    "source": "select c.uuid, document_number, description_text, description_length from (select uuid from {elastic_production_source}pg_detail_desc_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}pg_detail_desc_text c on c.uuid=inner_q.uuid",
+    "source": "select c.uuid, document_number, description_text, description_length, document_date from {elastic_production_source}.pg_detail_desc_text_delta where uuid > '{{offset}}' order by uuid limit {{limit}}",
     "field_mapping": {
       "uuid": 0,
       "document_number": 1,
       "description_text": 2,
-      "description_length": 3
+      "description_length": 3,
+      "document_date": 4
     },
-    "count_source": "select count(1) from {elastic_production_source}pg_detail_desc_text",
+    "count_source": "select count(1) from {elastic_production_source}.pg_detail_desc_text_delta",
     "key_field": "uuid",
     "chunksize": 100000
   },
   "target_setting": {
-    "index": "pg_detail_desc_text",
+    "index": "pg_detail_desc_texts",
     "indexing_batch_size": 1000,
     "id_field": "uuid"
   }

--- a/src/es_data_load/pv/mappings/production/pregrant/detail_desc_text.json
+++ b/src/es_data_load/pv/mappings/production/pregrant/detail_desc_text.json
@@ -1,0 +1,19 @@
+{
+  "source_setting": {
+    "source": "select c.uuid, document_number, description_text, description_length from (select uuid from {elastic_production_source}pg_detail_desc_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}pg_detail_desc_text c on c.uuid=inner_q.uuid",
+    "field_mapping": {
+      "uuid": 0,
+      "document_number": 1,
+      "description_text": 2,
+      "description_length": 3
+    },
+    "count_source": "select count(1) from {elastic_production_source}pg_detail_desc_text",
+    "key_field": "uuid",
+    "chunksize": 100000
+  },
+  "target_setting": {
+    "index": "pg_detail_desc_text",
+    "indexing_batch_size": 1000,
+    "id_field": "uuid"
+  }
+}

--- a/src/es_data_load/pv/mappings/production/pregrant/draw_desc_text.json
+++ b/src/es_data_load/pv/mappings/production/pregrant/draw_desc_text.json
@@ -1,0 +1,19 @@
+{
+  "source_setting": {
+    "source": "select c.uuid, document_number, draw_desc_text, draw_desc_sequence from (select uuid from {elastic_production_source}pg_draw_desc_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}pg_draw_desc_text c on c.uuid=inner_q.uuid",
+    "field_mapping": {
+      "uuid": 0,
+      "document_number": 1,
+      "description_text": 2,
+      "description_sequence": 3
+    },
+    "count_source": "select count(1) from {elastic_production_source}pg_draw_desc_text",
+    "key_field": "uuid",
+    "chunksize": 100000
+  },
+  "target_setting": {
+    "index": "pg_draw_desc_text",
+    "indexing_batch_size": 15000,
+    "id_field": "uuid"
+  }
+}

--- a/src/es_data_load/pv/mappings/production/pregrant/draw_desc_text.json
+++ b/src/es_data_load/pv/mappings/production/pregrant/draw_desc_text.json
@@ -1,18 +1,19 @@
 {
   "source_setting": {
-    "source": "select c.uuid, document_number, draw_desc_text, draw_desc_sequence from (select uuid from {elastic_production_source}pg_draw_desc_text where uuid > '{{offset}}' order by uuid limit {{limit}}) inner_q join {elastic_production_source}pg_draw_desc_text c on c.uuid=inner_q.uuid",
+    "source": "select c.uuid, document_number, draw_desc_text, draw_desc_sequence, document_date from {elastic_production_source}.pg_draw_desc_text_delta where uuid > '{{offset}}' order by uuid limit {{limit}}",
     "field_mapping": {
       "uuid": 0,
       "document_number": 1,
-      "description_text": 2,
-      "description_sequence": 3
+      "draw_desc_text": 2,
+      "draw_desc_sequence": 3,
+      "document_date": 4
     },
-    "count_source": "select count(1) from {elastic_production_source}pg_draw_desc_text",
+    "count_source": "select count(1) from {elastic_production_source}.pg_draw_desc_text_delta",
     "key_field": "uuid",
     "chunksize": 100000
   },
   "target_setting": {
-    "index": "pg_draw_desc_text",
+    "index": "pg_draw_desc_texts",
     "indexing_batch_size": 15000,
     "id_field": "uuid"
   }

--- a/src/es_data_load/pv/mappings/production/pregrant/publications.json
+++ b/src/es_data_load/pv/mappings/production/pregrant/publications.json
@@ -31,7 +31,7 @@
           "assignee_type": 5,
           "document_number": 9
         },
-        "source": "SELECT  assignee_id  , name_first  , name_last  , organization  , sequence  , type  , city  , state  , country  , a.document_number  , location_id from {elastic_production_source}.publication_assignee a inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = a.document_number;"
+        "source": "SELECT assignee_id , name_first , name_last , organization , sequence , type , city , state , country , a.document_number , location_id from {elastic_production_source}.publication_assignee a inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = a.document_number;"
       },
       "cpc_at_issue": {
         "field_mapping": {
@@ -47,10 +47,10 @@
           "action_date": 10,
           "document_number": 9
         },
-        "source": "select c.sequence, c.cpc_section, c.cpc_class,c.cpc_class,c.cpc_subclass,c.cpc_subclass, c.cpc_group,c.cpc_group,c.cpc_type, c.document_number, c.action_date from {elastic_production_source}.publication_cpc_at_issue c inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = c.document_number;"
+        "source": "select c.sequence, c.cpc_section, c.cpc_class, c.cpc_class, c.cpc_subclass, c.cpc_subclass, c.cpc_group, c.cpc_group, c.cpc_type, c.document_number, c.action_date from {elastic_production_source}.publication_cpc_at_issue c inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = c.document_number;"
       },
       "cpc_current": {
-        "source": "select c.sequence, c.cpc_section, c.cpc_class,c.cpc_class,c.cpc_subclass,c.cpc_subclass, c.cpc_group,c.cpc_group,c.cpc_type, c.document_number from {elastic_production_source}.publication_cpc_current as c join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}})p on p.document_number=c.document_number;",
+        "source": "select c.sequence, c.cpc_section, c.cpc_class, c.cpc_class, c.cpc_subclass, c.cpc_subclass, c.cpc_group, c.cpc_group, c.cpc_type, c.document_number from {elastic_production_source}.publication_cpc_current as c join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}})p on p.document_number=c.document_number;",
         "field_mapping": {
           "cpc_sequence": 0,
           "cpc_section": 1,
@@ -73,7 +73,7 @@
           "priority_claim_kind": 0,
           "priority_claim_sequence": 5
         },
-        "source": "select f.kind,f.foreign_doc_number,f.date,f.country,f.document_number,f.sequence from {elastic_production_source}.foreign_priority f inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = f.document_number;"
+        "source": "select f.kind, f.foreign_doc_number, f.date, f.country, f.document_number, f.sequence from {elastic_production_source}.foreign_priority f inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = f.document_number;"
       },
       "gov_interest_organizations": {
         "field_mapping": {
@@ -83,7 +83,7 @@
           "level_three": 3,
           "level_two": 2
         },
-        "source": "select c.name,c.level_one,c.level_two,c.level_three,c.document_number  from {elastic_production_source}.publication_gov_interest_organizations c inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = c.document_number;"
+        "source": "select c.name, c.level_one, c.level_two, c.level_three, c.document_number from {elastic_production_source}.publication_gov_interest_organizations c inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = c.document_number;"
       },
       "granted_pregrant_crosswalk": {
         "field_mapping": {
@@ -93,7 +93,7 @@
           "current_document_number_flag": 3,
           "current_patent_id_flag": 4
         },
-        "source": "select g.document_number,g.patent_id,g.application_number,g.current_pgpub_id_flag,g.current_patent_id_flag from {elastic_production_source}.granted_pregrant_crosswalk g inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = g.document_number;"
+        "source": "select g.document_number, g.patent_id, g.application_number, g.current_pgpub_id_flag, g.current_patent_id_flag from {elastic_production_source}.granted_pregrant_crosswalk g inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = g.document_number;"
       },
       "inventors": {
         "field_mapping": {
@@ -107,7 +107,7 @@
           "inventor_sequence": 3,
           "inventor_state": 5
         },
-        "source": "select inventor_id, name_first, name_last, sequence,city, state, country, i.document_number, location_id from {elastic_production_source}.publication_inventor i inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = i.document_number;"
+        "source": "select inventor_id, name_first, name_last, sequence, city, state, country, i.document_number, location_id from {elastic_production_source}.publication_inventor i inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = i.document_number;"
       },
       "ipcr": {
         "field_mapping": {
@@ -139,7 +139,7 @@
           "filed_country": 7,
           "published_filed_date": 0
         },
-        "source": "select p.date,p.371_date,p.102_date,p.kind,p.pct_doc_number,p.doc_type, p.document_number,p.country from {elastic_production_source}.publication_pct_data  p inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) pb on pb.document_number = p.document_number;"
+        "source": "select p.date, p.371_date, p.102_date, p.kind, p.pct_doc_number, p.doc_type, p.document_number, p.country from {elastic_production_source}.publication_pct_data p inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) pb on pb.document_number = p.document_number;"
       },
       "us_parties": {
         "field_mapping": {
@@ -165,7 +165,7 @@
           "related_doc_type": 0,
           "related_doc_sequence": 6
         },
-        "source": "select u.doc_type,u.relkind,u.related_doc_number,u.country,u.date,u.document_number,u.sequence   from {elastic_production_source}.publication_us_related_documents u inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = u.document_number;"
+        "source": "select u.doc_type, u.relkind, u.related_doc_number, u.country, u.date, u.document_number, u.sequence from {elastic_production_source}.publication_us_related_documents u inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = u.document_number;"
       },
       "uspc_at_issue": {
         "field_mapping": {
@@ -176,7 +176,7 @@
           "uspc_subclass": 2,
           "uspc_subclass_id": 3
         },
-        "source": "select u.mainclass_id,u.mainclass_id,u.subclass_id,u.subclass_id,u.sequence,u.document_number from {elastic_production_source}.publication_uspc_at_issue  u inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = u.document_number;"
+        "source": "select u.mainclass_id, u.mainclass_id, u.subclass_id, u.subclass_id, u.sequence, u.document_number from {elastic_production_source}.publication_uspc_at_issue u inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = u.document_number;"
       },
       "wipo": {
         "field_mapping": {
@@ -186,10 +186,10 @@
           "wipo_field_id": 0,
           "wipo_sequence": 2
         },
-        "source": "select w.field_id,w.field_title,w.sequence,w.document_number,w.sector_title from {elastic_production_source}.publication_wipo  w inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = w.document_number;"
+        "source": "select w.field_id, w.field_title, w.sequence, w.document_number, w.sector_title from {elastic_production_source}.publication_wipo w inner join (select document_number from {elastic_production_source}.publication where document_number > '{{offset}}' order by document_number limit {{limit}}) p on p.document_number = w.document_number;"
       }
     },
-    "source": "SELECT p.document_number, type  , date  , year  , title  , abstract  , kind  , country  , application_number  , series_code  , rule_47_flag from {elastic_production_source}.publication p where document_number > '{{offset}}' order by document_number limit {{limit}};"
+    "source": "SELECT p.document_number, type , date , year , title , abstract , kind , country , application_number , series_code , rule_47_flag from {elastic_production_source}.publication p where document_number > '{{offset}}' order by document_number limit {{limit}};"
   },
   "target_setting": {
     "id_field": "document_number",

--- a/src/es_data_load/pv/mappings/staging/cpc_class.json
+++ b/src/es_data_load/pv/mappings/staging/cpc_class.json
@@ -2,7 +2,6 @@
   "source_setting": {
     "source": "select id, id, title, num_assignees, num_inventors, num_patents, first_seen_date, last_seen_date, years_active from elastic_staging.cpc_class order by id limit {limit} offset {offset};",
     "field_mapping": {
-      "uuid": 0,
       "cpc_class_id": 1,
       "cpc_class_title": 2,
       "cpc_class": 1,

--- a/src/es_data_load/pv/mappings/staging/cpc_class.json
+++ b/src/es_data_load/pv/mappings/staging/cpc_class.json
@@ -1,6 +1,6 @@
 {
   "source_setting": {
-    "source": "select id, id, title, num_assignees, num_inventors, num_patents, first_seen_date, last_seen_date, years_active from elastic_staging.cpc_class  order by id limit {limit} offset {offset};",
+    "source": "select id, id, title, num_assignees, num_inventors, num_patents, first_seen_date, last_seen_date, years_active from elastic_staging.cpc_class order by id limit {limit} offset {offset};",
     "field_mapping": {
       "uuid": 0,
       "cpc_class_id": 1,
@@ -14,7 +14,7 @@
       "cpc_class_years_active": 8
     },
     "key_field": "uuid",
-    "count_source": "SELECT count(1) from  elastic_staging.cpc_class",
+    "count_source": "SELECT count(1) from elastic_staging.cpc_class",
     "chunksize": 10000
   },
   "target_setting": {

--- a/src/es_data_load/pv/mappings/staging/cpc_group.json
+++ b/src/es_data_load/pv/mappings/staging/cpc_group.json
@@ -2,7 +2,6 @@
   "source_setting": {
     "source": "select id, id, SUBSTR(id, 1, 3) class, SUBSTR(id, 1, 4) subclass, title from elastic_staging.cpc_group order by id limit {limit} offset {offset};",
     "field_mapping": {
-      "uuid": 0,
       "cpc_class": 2,
       "cpc_class_id": 2,
       "cpc_subclass_id": 3,

--- a/src/es_data_load/pv/mappings/staging/cpc_group.json
+++ b/src/es_data_load/pv/mappings/staging/cpc_group.json
@@ -1,6 +1,6 @@
 {
   "source_setting": {
-    "source": "select id, id, SUBSTR(id,1,3) class, SUBSTR(id,1,4) subclass, title from elastic_staging.cpc_group order by id limit {limit} offset {offset};",
+    "source": "select id, id, SUBSTR(id, 1, 3) class, SUBSTR(id, 1, 4) subclass, title from elastic_staging.cpc_group order by id limit {limit} offset {offset};",
     "field_mapping": {
       "uuid": 0,
       "cpc_class": 2,
@@ -10,7 +10,7 @@
       "cpc_group_id":1,
       "cpc_group_title": 4
     },
-    "count_source": "SELECT count(1) from  elastic_staging.cpc_group",
+    "count_source": "SELECT count(1) from elastic_staging.cpc_group",
     "chunksize": 10000,
         "key_field": "uuid"
   },

--- a/src/es_data_load/pv/mappings/staging/cpc_subclass.json
+++ b/src/es_data_load/pv/mappings/staging/cpc_subclass.json
@@ -1,6 +1,6 @@
 {
   "source_setting": {
-    "source": "select id, SUBSTR(id,1,3 ) class_id,id , title, num_assignees, num_inventors, num_patents, first_seen_date, last_seen_date, years_active from elastic_staging.cpc_subclass  order by id limit {limit} offset {offset};",
+    "source": "select id, SUBSTR(id, 1, 3 ) class_id, id , title, num_assignees, num_inventors, num_patents, first_seen_date, last_seen_date, years_active from elastic_staging.cpc_subclass order by id limit {limit} offset {offset};",
     "field_mapping": {
       "uuid": 0,
       "cpc_class": 1,
@@ -15,7 +15,7 @@
       "cpc_subclass_last_seen_date": 8,
       "cpc_subclass_years_active": 9
     },
-    "count_source": "SELECT count(1) from  elastic_staging.cpc_subclass",
+    "count_source": "SELECT count(1) from elastic_staging.cpc_subclass",
     "chunksize": 10000,
         "key_field": "uuid"
   },

--- a/src/es_data_load/pv/mappings/staging/fcitation.json
+++ b/src/es_data_load/pv/mappings/staging/fcitation.json
@@ -1,6 +1,6 @@
 {
   "source_setting": {
-    "source": "select\n    uuid, patent_id, date, number, country, category, sequence, patent_zero_prefix\nfrom elastic_staging.foreign_citations\n order by patent_zero_prefix limit {limit} offset {offset};",
+    "source": "select uuid, patent_id, date, number, country, category, sequence, patent_zero_prefix from elastic_staging.foreign_citations order by patent_zero_prefix limit {limit} offset {offset};",
     "field_mapping": {
       "uuid": 0,
       "patent_id": 1,

--- a/src/es_data_load/pv/mappings/staging/ipcr.json
+++ b/src/es_data_load/pv/mappings/staging/ipcr.json
@@ -1,6 +1,6 @@
  {
   "source_setting": {
-    "source": "select ipcr_id, section, ipc_class, subclass from elastic_staging.ipcr  order by ipcr_id limit {limit} offset {offset};",
+    "source": "select ipcr_id, section, ipc_class, subclass from elastic_staging.ipcr order by ipcr_id limit {limit} offset {offset};",
     "field_mapping": {
       "uuid": 0,
       "ipc_id": 0,
@@ -8,7 +8,7 @@
       "ipc_class": 2 ,
       "ipc_subclass": 3
     },
-    "count_source": "SELECT count(1) from  elastic_staging.ipcr",
+    "count_source": "SELECT count(1) from elastic_staging.ipcr",
     "chunksize": 10000,
         "key_field": "uuid"
   },

--- a/src/es_data_load/pv/mappings/staging/oreference.json
+++ b/src/es_data_load/pv/mappings/staging/oreference.json
@@ -1,6 +1,6 @@
 {
   "source_setting": {
-    "source": "select\n    uuid, patent_id, text, sequence, patent_zero_prefix\nfrom elastic_staging.other_reference\n order by patent_zero_prefix limit {limit} offset {offset};",
+    "source": "select uuid, patent_id, text, sequence, patent_zero_prefix from elastic_staging.other_reference order by patent_zero_prefix limit {limit} offset {offset};",
     "field_mapping": {
       "uuid": 0,
       "patent_id": 1,

--- a/src/es_data_load/pv/mappings/staging/patents.json
+++ b/src/es_data_load/pv/mappings/staging/patents.json
@@ -1,6 +1,6 @@
 {
   "source_setting": {
-    "source": "SELECT patent_id, type  , date  , year  , title  , abstract  , kind  , detail_desc_length  , num_foreign_documents_cited  , num_us_patents_cited  , num_us_applications_cited  , num_total_documents_cited  , num_times_cited_by_us_patents  , cpc_current_group_average_patent_processing_days  , uspc_current_mainclass_average_patent_processing_days  , patent_processing_days  , earliest_application_date  , term_extension, gi_statement, patent_zero_prefix from elastic_staging.patents order by patent_id limit {limit} offset {offset};",
+    "source": "SELECT patent_id, type , date , year , title , abstract , kind , detail_desc_length , num_foreign_documents_cited , num_us_patents_cited , num_us_applications_cited , num_total_documents_cited , num_times_cited_by_us_patents , cpc_current_group_average_patent_processing_days , uspc_current_mainclass_average_patent_processing_days , patent_processing_days , earliest_application_date , term_extension, gi_statement, patent_zero_prefix from elastic_staging.patents order by patent_id limit {limit} offset {offset};",
     "field_mapping": {
       "patent_id": 0,
       "patent_title": 4,
@@ -26,7 +26,7 @@
     "key_field": "patent_id",
     "nested_fields": {
       "application": {
-        "source": "select a.application_id, a.type, a.date,a.series_code,case when a.rule_47_flag=0 then 'false' else 'true' end,a.type, a.patent_id from elastic_staging.patent_application a join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=a.patent_id",
+        "source": "select a.application_id, a.type, a.date, a.series_code, case when a.rule_47_flag=0 then 'false' else 'true' end, a.type, a.patent_id from elastic_staging.patent_application a join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=a.patent_id",
         "field_mapping": {
           "application_id": 0,
           "application_type": 1,
@@ -38,7 +38,7 @@
         }
       },
       "attorneys": {
-        "source": "select a.persistent_lawyer_id, a.name_first, a.name_last,a.organization,a.sequence, a.patent_id from elastic_staging.patent_attorneys a join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=a.patent_id",
+        "source": "select a.persistent_lawyer_id, a.name_first, a.name_last, a.organization, a.sequence, a.patent_id from elastic_staging.patent_attorneys a join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=a.patent_id",
         "field_mapping": {
           "attorney_id": 0,
           "attorney_name_first": 1,
@@ -57,7 +57,7 @@
         }
       },
       "cpc_at_issue": {
-        "source": "select c.sequence, c.cpc_section, c.cpc_class,c.cpc_class,c.cpc_subclass,c.cpc_subclass, c.cpc_group,c.cpc_group,c.cpc_type, c.patent_id from elastic_staging.patent_cpc_at_issue c join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=c.patent_id",
+        "source": "select c.sequence, c.cpc_section, c.cpc_class, c.cpc_class, c.cpc_subclass, c.cpc_subclass, c.cpc_group, c.cpc_group, c.cpc_type, c.patent_id from elastic_staging.patent_cpc_at_issue c join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=c.patent_id",
         "field_mapping": {
           "cpc_sequence": 0,
           "cpc_section": 1,
@@ -72,7 +72,7 @@
         }
       },
       "examiners": {
-        "source": "select e.persistent_examiner_id,e.name_first,e.name_last,e.role,e.`group`,e.patent_id from elastic_staging.patent_examiner e join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=e.patent_id",
+        "source": "select e.persistent_examiner_id, e.name_first, e.name_last, e.role, e.`group`,e.patent_id from elastic_staging.patent_examiner e join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=e.patent_id",
         "field_mapping": {
           "examiner_id": 0,
           "examiner_first_name": 1,
@@ -83,7 +83,7 @@
         }
       },
       "granted_pregrant_crosswalk": {
-        "source": "select g.patent_id,g.document_number,g.document_number,g.application_number from elastic_staging.granted_pregrant_crosswalk g join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=g.patent_id",
+        "source": "select g.patent_id, g.document_number, g.document_number, g.application_number from elastic_staging.granted_pregrant_crosswalk g join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=g.patent_id",
         "field_mapping": {
           "patent_id": 0,
           "document_number": 1,
@@ -100,7 +100,7 @@
         }
       },
       "foreign_priority": {
-        "source": "select f.sequence,f.kind,f.foreign_doc_number,f.date,f.country,f.patent_id from elastic_staging.patent_foreign_priority f join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=f.patent_id",
+        "source": "select f.sequence, f.kind, f.foreign_doc_number, f.date, f.country, f.patent_id from elastic_staging.patent_foreign_priority f join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=f.patent_id",
         "field_mapping": {
           "priority_claim_sequence": 0,
           "priority_claim_kind": 1,
@@ -111,14 +111,14 @@
         }
       },
       "gov_interest_contract_award_numbers": {
-        "source": "select c.award_number,c.patent_id   from elastic_staging.patent_gov_contract c join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on c.patent_id = p.patent_id;",
+        "source": "select c.award_number, c.patent_id from elastic_staging.patent_gov_contract c join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on c.patent_id = p.patent_id;",
         "field_mapping": {
           "award_number": 0,
           "patent_id": 1
         }
       },
       "gov_interest_organizations": {
-        "source": "select c.name,c.level_one,c.level_two,c.level_three,c.patent_id  from elastic_staging.patent_gov_interest_organizations c join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on c.patent_id = p.patent_id;",
+        "source": "select c.name, c.level_one, c.level_two, c.level_three, c.patent_id from elastic_staging.patent_gov_interest_organizations c join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on c.patent_id = p.patent_id;",
         "field_mapping": {
           "fedagency_name": 0,
           "level_one": 1,
@@ -145,7 +145,7 @@
         }
       },
       "applicants": {
-        "source": "select a.fname,a.lname,a.organization,a.sequence,a.designation,a.applicant_type,a.persistent_location_id,a.patent_id from elastic_staging.patent_applicant  a join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on p.patent_id = a.patent_id;",
+        "source": "select a.fname, a.lname, a.organization, a.sequence, a.designation, a.applicant_type, a.persistent_location_id, a.patent_id from elastic_staging.patent_applicant a join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on p.patent_id = a.patent_id;",
         "field_mapping": {
           "applicant_name_first": 0,
           "applicant_name_last": 1,
@@ -158,7 +158,7 @@
         }
       },
       "pct_data": {
-        "source": "select p.date,p.`102_date`,p.`371_date`,p.kind,p.doc_number,p.doc_type, p.patent_id from elastic_staging.patent_pct_data  p join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p2 on p.patent_id = p2.patent_id;",
+        "source": "select p.date, p.`102_date`,p.`371_date`,p.kind, p.doc_number, p.doc_type, p.patent_id from elastic_staging.patent_pct_data p join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p2 on p.patent_id = p2.patent_id;",
         "field_mapping": {
           "published_filed_date": 0,
           "pct_102_date": 1,
@@ -170,7 +170,7 @@
         }
       },
       "us_related_documents": {
-        "source": "select u.doctype,u.kind,u.reldocno,u.country,u.date,u.status,u.sequence,u.kind,u.patent_id   from elastic_staging.patent_us_related_documents u join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on u.patent_id = p.patent_id;",
+        "source": "select u.doctype, u.kind, u.reldocno, u.country, u.date, u.status, u.sequence, u.kind, u.patent_id from elastic_staging.patent_us_related_documents u join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on u.patent_id = p.patent_id;",
         "field_mapping": {
           "related_doc_type": 0,
           "related_doc_kind": 1,
@@ -184,7 +184,7 @@
         }
       },
       "us_term_of_grant": {
-        "source": "select u.term_grant,u.term_extension,u.term_disclaimer,u.disclaimer_date,u.patent_id from elastic_staging.patent_us_term_of_grant  u join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on u.patent_id = p.patent_id;",
+        "source": "select u.term_grant, u.term_extension, u.term_disclaimer, u.disclaimer_date, u.patent_id from elastic_staging.patent_us_term_of_grant u join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on u.patent_id = p.patent_id;",
         "field_mapping": {
           "term_grant": 0,
           "term_extension": 1,
@@ -194,7 +194,7 @@
         }
       },
       "uspc_at_issue": {
-        "source": "select u.mainclass_id,u.mainclass_id,u.subclass_id,u.subclass_id,u.sequence,u.patent_id from elastic_staging.patent_uspc_at_issue  u join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on u.patent_id = p.patent_id;",
+        "source": "select u.mainclass_id, u.mainclass_id, u.subclass_id, u.subclass_id, u.sequence, u.patent_id from elastic_staging.patent_uspc_at_issue u join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on u.patent_id = p.patent_id;",
         "field_mapping": {
           "uspc_mainclass": 0,
           "uspc_mainclass_id": 1,
@@ -205,7 +205,7 @@
         }
       },
       "wipo": {
-        "source": "select w.field_id,w.field_id,w.sequence,w.patent_id from elastic_staging.patent_wipo  w join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on w.patent_id = p.patent_id;",
+        "source": "select w.field_id, w.field_id, w.sequence, w.patent_id from elastic_staging.patent_wipo w join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset}) p on w.patent_id = p.patent_id;",
         "field_mapping": {
           "wipo_field_id": 0,
           "wipo_field": 1,
@@ -214,7 +214,7 @@
         }
       },
       "assignees": {
-        "source": "SELECT  persistent_assignee_id  , name_first  , name_last  , organization  , sequence  , type  , city  , state  , country  , a.patent_id  , persistent_location_id from elastic_staging.patent_assignee a join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=a.patent_id",
+        "source": "SELECT persistent_assignee_id , name_first , name_last , organization , sequence , type , city , state , country , a.patent_id , persistent_location_id from elastic_staging.patent_assignee a join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=a.patent_id",
         "field_mapping": {
           "assignee_id": 0,
           "assignee_type": 5,
@@ -230,7 +230,7 @@
         }
       },
       "inventors": {
-        "source": "select persistent_inventor_id, name_first, name_last, sequence,city, state, country, i.patent_id, persistent_location_id from elastic_staging.patent_inventor i join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=i.patent_id",
+        "source": "select persistent_inventor_id, name_first, name_last, sequence, city, state, country, i.patent_id, persistent_location_id from elastic_staging.patent_inventor i join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=i.patent_id",
         "field_mapping": {
           "inventor_id": 0,
           "inventor_name_first": 1,
@@ -244,7 +244,7 @@
         }
       },
       "cpc_current": {
-        "source": "select c.sequence, c.cpc_section, c.cpc_class,c.cpc_class,c.cpc_subclass,c.cpc_subclass, c.cpc_group,c.cpc_group,c.cpc_type, c.patent_id from elastic_staging.patent_cpc_current as c join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=c.patent_id",
+        "source": "select c.sequence, c.cpc_section, c.cpc_class, c.cpc_class, c.cpc_subclass, c.cpc_subclass, c.cpc_group, c.cpc_group, c.cpc_type, c.patent_id from elastic_staging.patent_cpc_current as c join (select patent_id from elastic_staging.patents order by patent_id limit {limit} offset {offset})p on p.patent_id=c.patent_id",
         "field_mapping": {
           "cpc_sequence": 0,
           "cpc_section": 1,

--- a/src/es_data_load/pv/mappings/staging/us_application_citations.json
+++ b/src/es_data_load/pv/mappings/staging/us_application_citations.json
@@ -15,7 +15,7 @@
     },
         "key_field": "uuid",
 
-    "count_source": "SELECT count(1) from  elastic_staging.us_application_citations",
+    "count_source": "SELECT count(1) from elastic_staging.us_application_citations",
     "chunksize": 10000
   },
   "target_setting": {

--- a/src/es_data_load/pv/mappings/staging/us_patent_citations.json
+++ b/src/es_data_load/pv/mappings/staging/us_patent_citations.json
@@ -16,7 +16,7 @@
     },
         "key_field": "uuid",
 
-    "count_source": "SELECT count(1) from  elastic_staging.us_patent_citations",
+    "count_source": "SELECT count(1) from elastic_staging.us_patent_citations",
     "chunksize": 10000
   },
   "target_setting": {

--- a/src/es_data_load/pv/mappings/staging/uspc_mainclass.json
+++ b/src/es_data_load/pv/mappings/staging/uspc_mainclass.json
@@ -1,6 +1,6 @@
 {
   "source_setting": {
-    "source": "select id, id, title, num_patents, num_inventors, num_assignees, first_seen_date, last_seen_date, years_active from PatentsView_20211230.uspc_mainclass  order by id limit {limit} offset {offset};",
+    "source": "select id, id, title, num_patents, num_inventors, num_assignees, first_seen_date, last_seen_date, years_active from PatentsView_20211230.uspc_mainclass order by id limit {limit} offset {offset};",
     "field_mapping": {
       "uuid": 0,
       "uspc_mainclass_id": 1,
@@ -14,7 +14,7 @@
     },
         "key_field": "uuid",
 
-    "count_source": "SELECT count(1) from  PatentsView_20211230.uspc_mainclass",
+    "count_source": "SELECT count(1) from PatentsView_20211230.uspc_mainclass",
     "chunksize": 10000
   },
   "target_setting": {

--- a/src/es_data_load/pv/mappings/staging/uspc_mainclass.json
+++ b/src/es_data_load/pv/mappings/staging/uspc_mainclass.json
@@ -2,7 +2,6 @@
   "source_setting": {
     "source": "select id, id, title, num_patents, num_inventors, num_assignees, first_seen_date, last_seen_date, years_active from PatentsView_20211230.uspc_mainclass order by id limit {limit} offset {offset};",
     "field_mapping": {
-      "uuid": 0,
       "uspc_mainclass_id": 1,
       "uspc_mainclass_title": 2,
       "uspc_mainclass_num_assignees": 5,

--- a/src/es_data_load/pv/mappings/staging/uspc_subclass.json
+++ b/src/es_data_load/pv/mappings/staging/uspc_subclass.json
@@ -10,7 +10,7 @@
     },
       "key_field": "uuid",
 
-    "count_source": "SELECT count(1) from  PatentsView_20211230.uspc_subclass",
+    "count_source": "SELECT count(1) from PatentsView_20211230.uspc_subclass",
     "chunksize": 10000
   },
   "target_setting": {

--- a/src/es_data_load/pv/mappings/staging/wipo.json
+++ b/src/es_data_load/pv/mappings/staging/wipo.json
@@ -1,13 +1,13 @@
 {
   "source_setting": {
-    "source": "select id, sector_title,field_title from elastic_staging.wipo_field  order by id limit {limit} offset {offset};",
+    "source": "select id, sector_title, field_title from elastic_staging.wipo_field order by id limit {limit} offset {offset};",
     "field_mapping": {
       "uuid": 0,
       "wipo_id": 0,
       "sector_title": 1,
       "field_title": 2
     },
-    "count_source": "SELECT count(1) from   elastic_staging.wipo_field",
+    "count_source": "SELECT count(1) from elastic_staging.wipo_field",
     "chunksize": 10000,
     "key_field": "uuid"
   },

--- a/src/es_data_load/pv/schemas/PVSchemaManager.py
+++ b/src/es_data_load/pv/schemas/PVSchemaManager.py
@@ -23,14 +23,18 @@ AVAILABLE_SCHEMA_FILES = {
         "uspc_mainclasses_fields.json": "uspc_mainclasses{suffix}",
         "uspc_subclasses_fields.json": "uspc_subclasses{suffix}",
         "wipo_fields.json": "wipo{suffix}",
-        "brf_sum_text.json": "brf_sum_text{suffix}",
-        "claim.json": "claim{suffix}",
-        "detail_desc_text.json": "detail_desc_text{suffix}",
-        "draw_desc_text.json": "draw_desc_text{suffix}",
+        "brf_sum_text.json": "g_brf_sum_texts{suffix}",
+        "claim.json": "g_claims{suffix}",
+        "detail_desc_text.json": "g_detail_desc_texts{suffix}",
+        "draw_desc_text.json": "g_draw_desc_texts{suffix}",
     },
     "pregrant": {
         "publication_fields.json": "publications{suffix}",
-        "rel_app_text_publications_fields.json": "rel_app_text_publications{suffix}"
+        "rel_app_text_publications_fields.json": "rel_app_text_publications{suffix}",
+        "brf_sum_text.json": "pg_brf_sum_texts{suffix}",
+        "claim.json": "pg_claims{suffix}",
+        "detail_desc_text.json": "pg_detail_desc_texts{suffix}",
+        "draw_desc_text.json": "pg_draw_desc_texts{suffix}",
     },
 }
 logger = logging.getLogger("es-data-load")

--- a/src/es_data_load/pv/schemas/granted/brf_sum_text.json
+++ b/src/es_data_load/pv/schemas/granted/brf_sum_text.json
@@ -10,5 +10,8 @@
   },
   "patent_zero_prefix": {
     "type": "keyword"
+  },
+  "document_date": {
+    "type": "date"
   }
 }

--- a/src/es_data_load/pv/schemas/granted/claim.json
+++ b/src/es_data_load/pv/schemas/granted/claim.json
@@ -1,4 +1,7 @@
 {
+  "uuid": {
+    "type": "keyword"
+  },
   "patent_id": {
     "type": "keyword"
   },
@@ -18,9 +21,6 @@
     "type": "keyword"
   },
   "patent_zero_prefix": {
-    "type": "keyword"
-  },
-  "uuid": {
     "type": "keyword"
   }
 }

--- a/src/es_data_load/pv/schemas/granted/claim.json
+++ b/src/es_data_load/pv/schemas/granted/claim.json
@@ -22,5 +22,8 @@
   },
   "patent_zero_prefix": {
     "type": "keyword"
+  },
+  "document_date": {
+    "type": "date"
   }
 }

--- a/src/es_data_load/pv/schemas/granted/detail_desc_text.json
+++ b/src/es_data_load/pv/schemas/granted/detail_desc_text.json
@@ -13,5 +13,8 @@
   },
   "patent_zero_prefix": {
     "type": "keyword"
+  },
+  "document_date": {
+    "type": "date"
   }
 }

--- a/src/es_data_load/pv/schemas/granted/detail_desc_text.json
+++ b/src/es_data_load/pv/schemas/granted/detail_desc_text.json
@@ -1,4 +1,7 @@
 {
+  "uuid": {
+    "type": "keyword"
+  },
   "patent_id": {
     "type": "keyword"
   },
@@ -9,9 +12,6 @@
     "type": "integer"
   },
   "patent_zero_prefix": {
-    "type": "keyword"
-  },
-  "document_number": {
     "type": "keyword"
   }
 }

--- a/src/es_data_load/pv/schemas/granted/draw_desc_text.json
+++ b/src/es_data_load/pv/schemas/granted/draw_desc_text.json
@@ -5,13 +5,16 @@
   "patent_id": {
     "type": "keyword"
   },
-  "description_text": {
+  "draw_desc_text": {
     "type": "text"
   },
-  "description_sequence": {
+  "draw_desc_sequence": {
     "type": "integer"
   },
   "patent_zero_prefix": {
     "type": "keyword"
+  },
+  "document_date": {
+    "type": "date"
   }
 }

--- a/src/es_data_load/pv/schemas/pregrant/brf_sum_text.json
+++ b/src/es_data_load/pv/schemas/pregrant/brf_sum_text.json
@@ -7,5 +7,8 @@
   },
   "summary_text": {
     "type": "text"
+  },
+  "document_date": {
+    "type": "date"
   }
 }

--- a/src/es_data_load/pv/schemas/pregrant/brf_sum_text.json
+++ b/src/es_data_load/pv/schemas/pregrant/brf_sum_text.json
@@ -2,13 +2,10 @@
   "uuid": {
     "type": "keyword"
   },
-  "patent_id": {
+  "document_number": {
     "type": "keyword"
   },
   "summary_text": {
     "type": "text"
-  },
-  "patent_zero_prefix": {
-    "type": "keyword"
   }
 }

--- a/src/es_data_load/pv/schemas/pregrant/claim.json
+++ b/src/es_data_load/pv/schemas/pregrant/claim.json
@@ -16,5 +16,8 @@
   },
   "claim_dependent": {
     "type": "keyword"
+  },
+  "document_date": {
+    "type": "date"
   }
 }

--- a/src/es_data_load/pv/schemas/pregrant/claim.json
+++ b/src/es_data_load/pv/schemas/pregrant/claim.json
@@ -2,16 +2,19 @@
   "uuid": {
     "type": "keyword"
   },
-  "patent_id": {
+  "document_number": {
+    "type": "keyword"
+   },
+  "claim_number": {
     "type": "keyword"
   },
-  "description_text": {
+  "claim_text": {
     "type": "text"
   },
-  "description_sequence": {
+  "claim_sequence": {
     "type": "integer"
   },
-  "patent_zero_prefix": {
+  "claim_dependent": {
     "type": "keyword"
   }
 }

--- a/src/es_data_load/pv/schemas/pregrant/detail_desc_text.json
+++ b/src/es_data_load/pv/schemas/pregrant/detail_desc_text.json
@@ -10,5 +10,8 @@
   },
   "description_length": {
     "type": "integer"
- }
+  },
+  "document_date": {
+    "type": "date"
+  }
 }

--- a/src/es_data_load/pv/schemas/pregrant/detail_desc_text.json
+++ b/src/es_data_load/pv/schemas/pregrant/detail_desc_text.json
@@ -2,16 +2,13 @@
   "uuid": {
     "type": "keyword"
   },
-  "patent_id": {
+  "document_number": {
     "type": "keyword"
-  },
+   },
   "description_text": {
     "type": "text"
   },
-  "description_sequence": {
+  "description_length": {
     "type": "integer"
-  },
-  "patent_zero_prefix": {
-    "type": "keyword"
-  }
+ }
 }

--- a/src/es_data_load/pv/schemas/pregrant/draw_desc_text.json
+++ b/src/es_data_load/pv/schemas/pregrant/draw_desc_text.json
@@ -2,16 +2,13 @@
   "uuid": {
     "type": "keyword"
   },
-  "patent_id": {
+  "document_number": {
     "type": "keyword"
-  },
+   },
   "description_text": {
     "type": "text"
   },
   "description_sequence": {
     "type": "integer"
-  },
-  "patent_zero_prefix": {
-    "type": "keyword"
-  }
+ }
 }

--- a/src/es_data_load/pv/schemas/pregrant/draw_desc_text.json
+++ b/src/es_data_load/pv/schemas/pregrant/draw_desc_text.json
@@ -5,10 +5,13 @@
   "document_number": {
     "type": "keyword"
    },
-  "description_text": {
+  "draw_desc_text": {
     "type": "text"
   },
-  "description_sequence": {
+  "draw_desc_sequence": {
     "type": "integer"
- }
+  },
+  "document_date": {
+    "type": "date"
+  }
 }

--- a/src/es_data_load/specification.py
+++ b/src/es_data_load/specification.py
@@ -1,5 +1,7 @@
 import logging
 from typing import List
+from es import ElasticsearchWrapper
+from DataSources import MySQLDataSource
 
 from es_data_load.lib.utilities import (
     load_config_dict_from_json_files,
@@ -52,9 +54,9 @@ class LoadJob:
     def __init__(
         self, 
         load_configuration: LoadConfiguration, 
-        data_source, 
-        search_wrapper, 
-        test
+        data_source: MySQLDataSource, 
+        search_wrapper: ElasticsearchWrapper, 
+        test: bool
     ):
         self.load_configuration = load_configuration
         self.data_source = data_source


### PR DESCRIPTION
adds functionality to create and populate separated granted and pre-grant elastic indices for document full-text.
additionally provides some readability and efficiency improvements.